### PR TITLE
JBPM-3747 Web Designer causes java.net.SocketException: Connection reset...

### DIFF
--- a/src/main/java/org/jbpm/designer/web/server/ServletUtil.java
+++ b/src/main/java/org/jbpm/designer/web/server/ServletUtil.java
@@ -247,6 +247,10 @@ public class ServletUtil {
 			//        .setRequestProperty("Accept", "application/binary");
 			checkConnection.connect();
 			_logger.info("check connection response code: " + checkConnection.getResponseCode());
+			InputStream is = checkConnection.getInputStream();
+			while(is.read() != -1) {
+				// read all response data
+			}
 			if (checkConnection.getResponseCode() == 200) {
 				return true;
 			}


### PR DESCRIPTION
Read all response data before leaving the method.

I have confirmed that this fix gets rid of the Exception.
