### PR TITLE
make sure http response header charset=UTF-8

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/filter/DesignerInjectionFilter.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/filter/DesignerInjectionFilter.java
@@ -31,12 +31,12 @@ public class DesignerInjectionFilter implements Filter {
 
 
         try {
-            PrintWriter out = response.getWriter();
             DesignerResponseWrapper wrapper = new DesignerResponseWrapper((HttpServletResponse) response);
             chain.doFilter(request, wrapper);
             if (!(((HttpServletResponse) response).containsHeader("Content-Encoding")) && response.getContentType() != null &&
                     response.getContentType().indexOf("text/html") >= 0) {
                 StringBuffer buff = wrapper.getBuffer();
+                PrintWriter out = response.getWriter();
                 // workaround for hosted gwt mode
                 if(!(((HttpServletRequest) request).getRequestURI().endsWith("hosted.html"))) {
                     String modifiedResponse = processContent(buff, rules);

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/inlineeditor.jsp
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/inlineeditor.jsp
@@ -1,3 +1,4 @@
+<%@ page contentType="text/html;charset=UTF-8" %>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:b3mn="http://b3mn.org/2007/b3mn" xmlns:ext="http://b3mn.org/2007/ext" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:atom="http://b3mn.org/2007/atom+xhtml">
 <head profile="http://purl.org/NET/erdf/profile">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
Currently http://localhost:8080/designer/?locale=ja responds with http header charset=ISO-8859-1 so FireFox opens the page with Windows-1252(ISO-8859-1) and some Unicode characters are garbled. (meta http-equiv="Content-Type" content="text/html; charset=UTF-8" doesn't help this problem)

HTTP/1.1 200 OK
Server: Apache-Coyote/1.1
X-Powered-By: JSP/2.2
Content-Type: text/html;charset=ISO-8859-1
Transfer-Encoding: chunked
Date: Wed, 03 Jul 2013 07:29:30 GMT

Two fixes to make sure http response header charset=UTF-8.

1) JSP requires <%@ page contentType="text/html;charset=UTF-8" %>  because default is ISO-8859-1.

2) Moved response.getWriter() after chain.doFilter() because getWriter() locks characterEncoding and subsequent response.setCharacterEncoding("UTF-8") will have no effect (e.g. in UberfireServlet.doGet())
