### PR TITLE
[JBPM-4215] filter out 'wid' files that are not MVEL

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/web/preprocessing/impl/JbpmPreprocessingUnit.java
@@ -595,7 +595,15 @@ public class JbpmPreprocessingUnit implements IDiagramPreprocessingUnit {
     }
 
     private Collection<Asset> findWorkitemInfoForUUID(String location, Repository repository) {
-        Collection<Asset> widAssets = repository.listAssets(location, new FilterByExtension(WORKITEM_DEFINITION_EXT));
+        Collection<Asset> widAssets = repository.listAssets(location, new FilterByExtension(WORKITEM_DEFINITION_EXT){
+
+            @Override
+            public boolean accept(org.uberfire.java.nio.file.Path path)
+            {
+                boolean accept = super.accept(path);
+                return accept && ! path.getFileName().toString().startsWith("."); // JBPM-4215 fix: filter out hidden files of the same suffix but different format
+            }
+        });
         return widAssets;
     }
 


### PR DESCRIPTION
This error has been reported on 6.0.0.Final but I just patched it on master.
