### PR TITLE
JBPM-5921: Fix jbpm-designer-standalone compilation error due to miss…

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -894,6 +894,7 @@
             <!-- Dashbuilder -->
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-json</compileSourcesArtifact>
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.dashbuilder:dashbuilder-dataset-api</compileSourcesArtifact>
           </compileSourcesArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
…ing dashbuilder dependency

@cristianonicolai Hi Cristian, will you confirm this fix - it seems related to https://github.com/kiegroup/droolsjbpm-integration/pull/924