### PR TITLE
[7.0.x] JBPM-5921: Fix jbpm-designer-standalone compilation error due…

### DIFF
--- a/jbpm-designer-standalone/pom.xml
+++ b/jbpm-designer-standalone/pom.xml
@@ -894,6 +894,7 @@
             <!-- Dashbuilder -->
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-json</compileSourcesArtifact>
             <compileSourcesArtifact>org.dashbuilder:dashbuilder-navigation-api</compileSourcesArtifact>
+            <compileSourcesArtifact>org.dashbuilder:dashbuilder-dataset-api</compileSourcesArtifact>
           </compileSourcesArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
… to missing dashbuilder dependency