### PR TITLE
JBPM-5975 Enumerations can't be used as predefined values

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -67,6 +67,7 @@
       <artifactId>kie-wb-common-services-api</artifactId>
     </dependency>
 
+
     <!-- start forms integration -->
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
@@ -556,6 +557,14 @@
       <artifactId>kie-wb-common-forms-fields</artifactId>
       <scope>test</scope>
       <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-ci</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
- Added direct dependency on org.eclipse.aether:aether-api
- Added direct dependency on org.kie:kie-ci
- Direct dependencies were added so that the workbench/Business Central can create the necessary ClassLoader, to be used when loading externally defined enumerations
- Added functionality to the evaluateWorkDefinitions method in JbpmPreprocessingUnit, to create a ClassLoader that can be used to load externally defined enumerations