### PR TITLE
JBPM-5736: Update taskforms component menu on task/process change.

### DIFF
--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderService.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderService.java
@@ -24,7 +24,7 @@ import javax.inject.Named;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.bpmn2.Definitions;
 import org.kie.workbench.common.forms.bpmn.BPMNFormBuilderService;
-import org.kie.workbench.common.forms.commons.layout.FormLayoutTemplateGenerator;
+import org.kie.workbench.common.forms.commons.shared.layout.FormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandlerManager;
 import org.kie.workbench.common.forms.jbpm.model.authoring.JBPMFormModel;
 import org.kie.workbench.common.forms.jbpm.server.service.BPMNFormModelGenerator;
@@ -74,10 +74,10 @@ public class BPMNKieWorkbenchFormBuilderService implements BPMNFormBuilderServic
         JBPMFormModel model;
 
         if (StringUtils.isEmpty(taskId)) {
-            model = generator.generateProcessFormModel(definition);
+            model = generator.generateProcessFormModel(definition, formPath);
         } else {
             model = generator.generateTaskFormModel(definition,
-                                                    taskId);
+                                                    taskId, formPath);
         }
 
         if (model == null) {


### PR DESCRIPTION
[Reopening](https://github.com/kiegroup/jbpm-designer/pull/627) again, this PR is part of an ensemble please don't merge until the others PR's are merged too.

JBPM-5736: Update taskforms component menu on task/process change.
JBPM-5985: Forms are generated incorrectly after a removal of the process/task variable.
JBPM-5723: If you delete a data field, there is no response in the form connected to it.
JBPM-5911: DatePicker should be created from LocalDate, LocalDateTime and OffsetDateTime data types.

@jsoltes @tsurdilo could you take a look?

Relates to:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/465
https://github.com/kiegroup/kie-wb-common/pull/946
https://github.com/kiegroup/jbpm-designer/pull/633
https://github.com/kiegroup/jbpm-wb/pull/778
https://github.com/kiegroup/kie-wb-distributions/pull/543