### PR TITLE
Fix typo in Process Documentation.

### DIFF
--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/processdoc/default.jsp
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/processdoc/default.jsp
@@ -303,7 +303,7 @@
                     "name":"Version","value":processVersion,"count":"6"
                 },
                 {
-                    "name":"Docmentation","value":processDocumentation,"count":"6"
+                    "name":"Documentation","value":processDocumentation,"count":"6"
                 }
             ]
         };


### PR DESCRIPTION
![proc-doc](https://user-images.githubusercontent.com/16349113/32211943-2308d8e4-be15-11e7-9614-46aa83d70179.png)
