### PR TITLE
Remove unused avalon-framework dependency

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -381,10 +381,6 @@
       <artifactId>org.osgi.compendium</artifactId>
     </dependency>
     <dependency>
-      <groupId>avalon-framework</groupId>
-      <artifactId>avalon-framework</artifactId>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>


### PR DESCRIPTION
avalon-framework is unused dependency declared (only in) jbpm-designer-backend. It's a project that is no longer maintained since 2004. I'm deleting it to remove useless jar from final kie-wb.war