### PR TITLE
AF-819: Renaming assets discards changes

### DIFF
--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerView.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerView.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.google.gwt.user.client.ui.ProvidesResize;
 import com.google.gwt.user.client.ui.RequiresResize;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorView;
+import org.uberfire.mvp.Command;
 
 public interface DesignerView
         extends KieEditorView,
@@ -48,5 +49,14 @@ public interface DesignerView
 
     void askOpenInXMLEditor();
 
+    void raiseEventUpdate();
+
     void raiseEventUpdateLock();
+
+    boolean canSaveDesignerModel();
+
+    void showYesNoCancelPopup(String title,
+                              String message,
+                              Command yesCommand,
+                              Command noCommand);
 }

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerViewImpl.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerViewImpl.java
@@ -22,6 +22,8 @@ import javax.inject.Inject;
 
 import com.google.gwt.user.client.ui.RequiresResize;
 import org.kie.workbench.common.widgets.metadata.client.KieEditorViewImpl;
+import org.uberfire.ext.widgets.common.client.common.popups.YesNoCancelPopup;
+import org.uberfire.mvp.Command;
 
 public class DesignerViewImpl
         extends KieEditorViewImpl
@@ -57,6 +59,11 @@ public class DesignerViewImpl
     @Override
     public void raiseEventSave() {
         designerWidget.raiseEventSave(designerWidget.getEditorID());
+    }
+
+    @Override
+    public void raiseEventUpdate() {
+        designerWidget.raiseEventUpdate(designerWidget.getEditorID());
     }
 
     @Override
@@ -100,7 +107,7 @@ public class DesignerViewImpl
 
     @Override
     public boolean canClose() {
-        if (!designerWidget.canSaveDesignerModel(designerWidget.getEditorID()) ||
+        if (!canSaveDesignerModel() ||
                 designerWidget.isProcessValidating(designerWidget.getEditorID())) {
             boolean canClose = designerWidget.confirmClose();
             if (canClose) {
@@ -114,6 +121,30 @@ public class DesignerViewImpl
         } else {
             return true;
         }
+    }
+
+    @Override
+    public boolean canSaveDesignerModel() {
+        return designerWidget.canSaveDesignerModel(designerWidget.getEditorID());
+    }
+
+    @Override
+    public void showYesNoCancelPopup(final String title,
+                                     final String message,
+                                     final Command yesCommand,
+                                     final Command noCommand) {
+
+        final Command cancelCommand = () -> {
+            // Do nothing, but let the cancel button be shown.
+        };
+        final YesNoCancelPopup yesNoCancelPopup = YesNoCancelPopup.newYesNoCancelPopup(title,
+                                                                                       message,
+                                                                                       yesCommand,
+                                                                                       noCommand,
+                                                                                       cancelCommand);
+        yesNoCancelPopup.clearScrollHeight();
+        yesNoCancelPopup.setClosable(false);
+        yesNoCancelPopup.show();
     }
 
     @Override

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerWidgetPresenter.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerWidgetPresenter.java
@@ -77,6 +77,10 @@ public class DesignerWidgetPresenter {
         view.raiseEventSave(editorID);
     }
 
+    public void raiseEventUpdate(final String editorID) {
+        view.raiseEventUpdate(editorID);
+    }
+
     public void raiseEventCheckSave(final String editorID,
                                     String pathURI) {
         view.raiseEventCheckSave(editorID,

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerWidgetView.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/DesignerWidgetView.java
@@ -199,6 +199,19 @@ public class DesignerWidgetView
         }
     }-*/;
 
+    public native void raiseEventUpdate(String editorID) /*-{
+        try {
+            if ($wnd.document.getElementById(editorID) && $wnd.document.getElementById(editorID).contentWindow.ORYX && $wnd.document.getElementById(editorID).contentWindow.ORYX.Editor && (typeof($wnd.document.getElementById(editorID).contentWindow.ORYX.Editor.checkIfSaved) == "function")) {
+                $wnd.document.getElementById(editorID).contentWindow.ORYX.EDITOR._pluginFacade.raiseEvent({
+                    type: "designereventdoupdate"
+                });
+            }
+        } catch (e) {
+            var ex = @com.google.gwt.core.client.JavaScriptException::new(Ljava/lang/Object;)(e);
+            @com.google.gwt.core.client.GWT::log(Ljava/lang/String;Ljava/lang/Throwable;)("JSNI raiseEventSave error", ex);
+        }
+    }-*/;
+
     public native void raiseEventCheckSave(String editorID,
                                            String pathURI) /*-{
         try {

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/resources/i18n/DesignerEditorConstants.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/resources/i18n/DesignerEditorConstants.java
@@ -91,4 +91,8 @@ public interface DesignerEditorConstants extends
     String CaseDefinition();
 
     String CaseIdPrefix();
+
+    String Information();
+
+    String ModelEditorConfirmSaveBeforeRename();
 }

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/client/resources/i18n/DesignerEditorConstants.properties
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/client/resources/i18n/DesignerEditorConstants.properties
@@ -32,3 +32,5 @@ ProcessModel=Process Model
 ConfirmCloseBusinessProcessEditor=Business Process may contain unsaved changes or process validation is still running. Are you sure you would like to close the editor?
 CaseDefinition=Case definition
 CaseIdPrefix=Case ID prefix (optional)
+Information=Information
+ModelEditorConfirmSaveBeforeRename=Do you want to save current changes prior to file renaming?

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/saveplugin.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/Plugins/saveplugin.js
@@ -162,6 +162,7 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
 
 
         this.facade.registerOnEvent(ORYX.CONFIG.EVENT_DO_SAVE, this.handleEventDoSave.bind(this));
+        this.facade.registerOnEvent(ORYX.CONFIG.EVENT_DO_UPDATE, this.handleEventDoUpdate.bind(this));
         this.facade.registerOnEvent(ORYX.CONFIG.EVENT_DO_CHECKSAVE, this.handleEventDoCheckSave.bind(this));
         this.facade.registerOnEvent(ORYX.CONFIG.EVENT_CANCEL_SAVE, this.handleEventCancelSave.bind(this));
         this.facade.registerOnEvent(ORYX.CONFIG.EVENT_DO_RELOAD, this.handleEventDoRealod.bind(this));
@@ -213,6 +214,11 @@ ORYX.Plugins.SavePlugin = Clazz.extend({
     handleEventDoSave: function() {
         this.setUnsaved();
         this.save(true);
+    },
+
+    handleEventDoUpdate: function() {
+        this.setUnsaved();
+        this.save(false);
     },
 
     handleEventDoCheckSave : function(options) {

--- a/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/config.js
+++ b/jbpm-designer-client/src/main/resources/org/jbpm/designer/public/js/config.js
@@ -323,6 +323,7 @@ ORYX.CONFIG.EVENT_MODE_CHANGED = "mode.changed";
 ORYX.CONFIG.EVENT_PAINT_CANVAS_TOGGLED  = "canvas.toggled";
 // save-cancel-reload
 ORYX.CONFIG.EVENT_DO_SAVE = "designereventdosave";
+ORYX.CONFIG.EVENT_DO_UPDATE = "designereventdoupdate";
 ORYX.CONFIG.EVENT_DO_CHECKSAVE = "designereventdochecksave";
 ORYX.CONFIG.EVENT_CANCEL_SAVE = "designereventcancelsave";
 ORYX.CONFIG.EVENT_DO_RELOAD = "designereventreloads";

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/DesignerPresenterTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/DesignerPresenterTest.java
@@ -24,6 +24,7 @@ import org.guvnor.common.services.project.client.context.WorkspaceProjectContext
 import org.guvnor.common.services.project.client.security.ProjectController;
 import org.guvnor.common.services.project.model.WorkspaceProject;
 import org.guvnor.common.services.shared.metadata.model.Overview;
+import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.designer.client.parameters.DesignerEditorParametersPublisher;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,14 +35,26 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.ObservablePath;
 import org.uberfire.backend.vfs.Path;
+import org.uberfire.ext.editor.commons.client.BaseEditorView;
+import org.uberfire.ext.editor.commons.client.file.CommandWithFileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.FileNameAndCommitMessage;
+import org.uberfire.ext.editor.commons.client.file.popups.RenamePopUpPresenter;
 import org.uberfire.ext.editor.commons.client.history.VersionRecordManager;
 import org.uberfire.ext.editor.commons.client.menu.BasicFileMenuBuilder;
+import org.uberfire.ext.editor.commons.client.validation.DefaultFileNameValidator;
+import org.uberfire.ext.editor.commons.service.RenameService;
+import org.uberfire.ext.widgets.common.client.callbacks.HasBusyIndicatorDefaultErrorCallback;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mvp.Command;
 import org.uberfire.workbench.model.menu.MenuItem;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -69,6 +82,10 @@ public class DesignerPresenterTest {
     protected WorkspaceProjectContext workbenchContext;
 
     @Mock
+    private RenameService renameService;
+    private CallerMock<RenameService> renameServiceCaller;
+
+    @Mock
     private DesignerView view;
 
     @Mock
@@ -77,13 +94,23 @@ public class DesignerPresenterTest {
     @Mock
     private DesignerEditorParametersPublisher designerEditorParametersPublisher;
 
+    @Mock
+    private RenamePopUpPresenter renamePopUpPresenter;
+
+    @Mock
+    private DefaultFileNameValidator fileNameValidator;
+
+    @Mock
+    private BaseEditorView baseView;
+
     @Spy
-    private Map<String, String> parameters = new HashMap<String, String>();
+    private Map<String, String> parameters = new HashMap<>();
 
     private DesignerPresenter presenter;
 
     @Before
     public void setup() {
+        renameServiceCaller = new CallerMock<>(renameService);
         presenter = spy(new DesignerPresenter(view) {
 
             {
@@ -92,6 +119,9 @@ public class DesignerPresenterTest {
                 this.workbenchContext = DesignerPresenterTest.this.workbenchContext;
                 this.versionRecordManager = DesignerPresenterTest.this.versionRecordManager;
                 this.designerEditorParametersPublisher = DesignerPresenterTest.this.designerEditorParametersPublisher;
+                this.renamePopUpPresenter = DesignerPresenterTest.this.renamePopUpPresenter;
+                this.fileNameValidator = DesignerPresenterTest.this.fileNameValidator;
+                this.baseView = DesignerPresenterTest.this.baseView;
             }
 
             @Override
@@ -132,8 +162,7 @@ public class DesignerPresenterTest {
         verify(fileMenuBuilder).addSave(any(MenuItem.class));
         verify(fileMenuBuilder).addCopy(any(Path.class),
                                         any(AssetUpdateValidator.class));
-        verify(fileMenuBuilder).addRename(any(Path.class),
-                                          any(AssetUpdateValidator.class));
+        verify(fileMenuBuilder).addRename(any(Command.class));
         verify(fileMenuBuilder).addDelete(any(Path.class),
                                           any(AssetUpdateValidator.class));
     }
@@ -151,10 +180,115 @@ public class DesignerPresenterTest {
                never()).addCopy(any(Path.class),
                                 any(AssetUpdateValidator.class));
         verify(fileMenuBuilder,
-               never()).addRename(any(Path.class),
-                                  any(AssetUpdateValidator.class));
+               never()).addRename(any(Command.class));
         verify(fileMenuBuilder,
                never()).addDelete(any(Path.class),
                                   any(AssetUpdateValidator.class));
+    }
+
+    @Test
+    public void testGetSaveAndRenameWhenAssetIsDirty() {
+
+        final String title = "title";
+        final String message = "message";
+        final Command doSaveAndRename = mock(Command.class);
+        final Command doRename = mock(Command.class);
+
+        doReturn(true).when(presenter).isDirty();
+        doReturn(title).when(presenter).getPopupTitle();
+        doReturn(message).when(presenter).getMessage();
+        doReturn(doSaveAndRename).when(presenter).doSaveAndRename();
+        doReturn(doRename).when(presenter).doRename();
+
+        presenter.getSaveAndRename().execute();
+
+        verify(view).showYesNoCancelPopup(title, message, doSaveAndRename, doRename);
+    }
+
+    @Test
+    public void testGetSaveAndRenameWhenAssetIsNotDirty() {
+
+        final Command doRename = mock(Command.class);
+
+        doReturn(false).when(presenter).isDirty();
+        doReturn(doRename).when(presenter).doRename();
+
+        presenter.getSaveAndRename().execute();
+
+        verify(doRename).execute();
+    }
+
+    @Test
+    public void testIsDirtyWhenDesignerModelCanBeSaved() {
+
+        doReturn(true).when(view).canSaveDesignerModel();
+
+        assertFalse(presenter.isDirty());
+    }
+
+    @Test
+    public void testIsDirtyWhenDesignerModelCannotBeSaved() {
+
+        doReturn(false).when(view).canSaveDesignerModel();
+
+        assertTrue(presenter.isDirty());
+    }
+
+    @Test
+    public void testDoSaveAndRename() {
+
+        final Command command = mock(Command.class);
+
+        doReturn(command).when(presenter).doRename();
+        doNothing().when(presenter).save(any());
+
+        presenter.doSaveAndRename().execute();
+
+        verify(presenter).save(command);
+    }
+
+    @Test
+    public void testDoRename() {
+
+        doNothing().when(presenter).openRenamePopUp(any());
+
+        presenter.doRename().execute();
+
+        verify(presenter).openRenamePopUp(any());
+    }
+
+    @Test
+    public void testOpenRenamePopUp() {
+
+        final ObservablePath observablePath = mock(ObservablePath.class);
+        final CommandWithFileNameAndCommitMessage command = mock(CommandWithFileNameAndCommitMessage.class);
+
+        doReturn(command).when(presenter).makeRenameCommand();
+
+        presenter.openRenamePopUp(observablePath);
+
+        verify(renamePopUpPresenter).show(observablePath, fileNameValidator, command);
+    }
+
+    @Test
+    public void testMakeRenameCommand() {
+
+        final FileNameAndCommitMessage details = mock(FileNameAndCommitMessage.class);
+        final ObservablePath observablePath = mock(ObservablePath.class);
+        final RemoteCallback successCallback = mock(RemoteCallback.class);
+        final HasBusyIndicatorDefaultErrorCallback errorCallback = mock(HasBusyIndicatorDefaultErrorCallback.class);
+        final String newFileName = "newFileName";
+        final String message = "message";
+
+        doReturn(newFileName).when(details).getNewFileName();
+        doReturn(message).when(details).getCommitMessage();
+        doReturn(observablePath).when(versionRecordManager).getPathToLatest();
+        doReturn(renameServiceCaller).when(presenter).getRenameService();
+        doReturn(successCallback).when(presenter).getRenameSuccessCallback(any());
+        doReturn(errorCallback).when(presenter).getRenameErrorCallback(any());
+
+        presenter.makeRenameCommand().execute(details);
+
+        verify(renameService).rename(observablePath, newFileName, message);
     }
 }


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBA-148
- https://issues.jboss.org/browse/AF-819

---
Demo:
![demo](https://user-images.githubusercontent.com/1079279/35909185-e79488d6-0bd9-11e8-8223-97e9718f444f.gif)

---

Important topics:

I) I'm keeping the editors, that have their own implementation of the save-and-rename operation, intact;

II) I couldn't apply the generic approach on `jbpm-designer`, due to the save operation that is coupled to native JS code. Thus, I needed to implement a custom solution there;

III) The "save commit" and the "rename commit" are not being squashed. I don't think that it's a problem since we're showing explicitly to the user that two operations are being executed (but, maybe I'm missing something, wdyt @manstis?).

---

Part of an ensemble:
- https://github.com/kiegroup/appformer/pull/170
- https://github.com/kiegroup/kie-wb-common/pull/1414
- https://github.com/kiegroup/drools-wb/pull/804
- https://github.com/kiegroup/optaplanner-wb/pull/251
- https://github.com/kiegroup/jbpm-designer/pull/743