### PR TITLE
BAPL-764-migration-tool: Provide migration path from old Form Modeler to the new one

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -89,7 +89,7 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
-      <artifactId>kie-wb-common-forms-serialization</artifactId>
+      <artifactId>kie-wb-common-forms-backend-services</artifactId>
     </dependency>
 
     <dependency>

--- a/jbpm-designer-backend/src/main/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderService.java
+++ b/jbpm-designer-backend/src/main/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderService.java
@@ -32,7 +32,7 @@ import org.kie.workbench.common.forms.jbpm.server.service.BPMNFormModelGenerator
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.BPMNFormGeneratorService;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.authoring.Authoring;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.io.IOService;
 

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderServiceTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderServiceTest.java
@@ -38,11 +38,11 @@ import org.kie.workbench.common.forms.jbpm.server.service.impl.BusinessProcessFo
 import org.kie.workbench.common.forms.jbpm.server.service.impl.TaskFormModelHandler;
 import org.kie.workbench.common.forms.jbpm.service.shared.BPMFinderService;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
-import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
 import org.kie.workbench.common.forms.service.shared.FieldManager;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormModelSerializer;
 import org.kie.workbench.common.services.backend.project.ModuleClassLoaderHelper;
 import org.kie.workbench.common.services.shared.project.KieModule;
 import org.kie.workbench.common.services.shared.project.KieModuleService;


### PR DESCRIPTION
There has been some packages changes.

@tsurdilo could you please review?

This PR is part of an ensemble, merge with:

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/720
https://github.com/kiegroup/kie-wb-common/pull/1492
https://github.com/kiegroup/jbpm-designer/pull/754
https://github.com/kiegroup/jbpm-wb/pull/993
https://github.com/kiegroup/kie-wb-distributions/pull/704