### PR TITLE
JBPM-8233 fixed compilation and tests for jbpm designer

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -342,14 +342,8 @@
       <artifactId>jaxb-impl</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -344,6 +344,12 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -340,13 +340,12 @@
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>

--- a/jbpm-designer-client/pom.xml
+++ b/jbpm-designer-client/pom.xml
@@ -190,20 +190,10 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- powermock -->
+    <!-- mocks -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/Assignment.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/Assignment.java
@@ -25,6 +25,8 @@ public class Assignment {
 
     AssignmentData assignmentData;
 
+    private static StringUtils stringUtils = new StringUtils();
+
     /*
         Assignments have either a processVar or a constant
      */
@@ -170,7 +172,7 @@ public class Assignment {
         if (getVariableType() == VariableType.INPUT) {
             if (getConstant() != null && !getConstant().isEmpty()) {
                 sb.append(INPUT_ASSIGNMENT_PREFIX).append(getName()).append(ASSIGNMENT_OPERATOR_TOCONSTANT).append(
-                        StringUtils.urlEncode(getConstant()));
+                        stringUtils.urlEncode(getConstant()));
             } else if (getProcessVarName() != null && !getProcessVarName().isEmpty()) {
                 sb.append(INPUT_ASSIGNMENT_PREFIX).append(getProcessVarName()).append(ASSIGNMENT_OPERATOR_TOVARIABLE).append(getName());
             } else {
@@ -225,7 +227,7 @@ public class Assignment {
             int i = sAssignment.indexOf(ASSIGNMENT_OPERATOR_TOCONSTANT);
             variableName = sAssignment.substring(0,
                                                  i);
-            constant = StringUtils.urlDecode(sAssignment.substring(i + ASSIGNMENT_OPERATOR_TOCONSTANT.length()));
+            constant = stringUtils.urlDecode(sAssignment.substring(i + ASSIGNMENT_OPERATOR_TOCONSTANT.length()));
         }
 
         // Create the new assignment
@@ -234,5 +236,10 @@ public class Assignment {
                               assignmentType,
                               processVariableName,
                               constant);
+    }
+
+    // for test purposes
+    static void setStringUtils(StringUtils utils) {
+        stringUtils = utils;
     }
 }

--- a/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/util/StringUtils.java
+++ b/jbpm-designer-client/src/main/java/org/jbpm/designer/client/shared/util/StringUtils.java
@@ -76,7 +76,7 @@ public class StringUtils {
      * @param s
      * @return
      */
-    public static String urlEncode(String s) {
+    public String urlEncode(String s) {
         if (s == null || s.isEmpty()) {
             return s;
         }
@@ -89,7 +89,7 @@ public class StringUtils {
      * @param s
      * @return
      */
-    public static String urlDecode(String s) {
+    public String urlDecode(String s) {
         if (s == null || s.isEmpty()) {
             return s;
         }

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentBaseTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentBaseTest.java
@@ -26,46 +26,35 @@ import com.google.gwt.junit.GWTMockUtilities;
 import org.jbpm.designer.client.resources.i18n.DesignerEditorConstants;
 import org.jbpm.designer.client.shared.util.StringUtils;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class AssignmentBaseTest {
+
+    protected StringUtils utils = spy(StringUtils.class);
 
     public void setUp() throws Exception {
         // Prevent runtime GWT.create() error at DesignerEditorConstants.INSTANCE
         GWTMockUtilities.disarm();
         // MockDesignerEditorConstants replaces DesignerEditorConstants.INSTANCE
-        final Answer answer = new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                return invocation.getMethod().getName();
-            }
-        };
-        final DesignerEditorConstants designerEditorConstants = PowerMockito.mock(DesignerEditorConstants.class,
-                                                                                  answer);
+        final Answer answer = invocation -> invocation.getMethod().getName();
+        final DesignerEditorConstants designerEditorConstants = mock(DesignerEditorConstants.class,
+                                                                     answer);
         setFinalStaticField(DesignerEditorConstants.class.getDeclaredField("INSTANCE"),
                             designerEditorConstants);
 
         // Mock StringUtils URL Encoding methods
-        PowerMockito.mockStatic(StringUtils.class);
-        PowerMockito.when(StringUtils.urlEncode(Mockito.anyString())).thenAnswer(new Answer<Object>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return urlEncode((String) args[0]);
-            }
+        Mockito.when(utils.urlEncode(Mockito.anyString())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            return urlEncode((String) args[0]);
         });
-        PowerMockito.when(StringUtils.urlDecode(Mockito.anyString())).thenAnswer(new Answer<Object>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                return urlDecode((String) args[0]);
-            }
+        Mockito.when(utils.urlDecode(Mockito.anyString())).thenAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            return urlDecode((String) args[0]);
         });
-
-        PowerMockito.when(StringUtils.createQuotedConstant(Mockito.anyString())).thenCallRealMethod();
-        PowerMockito.when(StringUtils.createUnquotedConstant(Mockito.anyString())).thenCallRealMethod();
+        Assignment.setStringUtils(utils);
     }
 
     public void tearDown() {

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentDataMarshallerTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentDataMarshallerTest.java
@@ -19,6 +19,7 @@ package org.jbpm.designer.client.shared;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,19 +27,16 @@ import java.util.Map;
 import org.jboss.errai.marshalling.client.api.MarshallingSession;
 import org.jboss.errai.marshalling.client.api.json.EJValue;
 import org.jboss.errai.marshalling.server.JSONStreamDecoder;
-import org.jbpm.designer.client.shared.util.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({StringUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class AssignmentDataMarshallerTest extends AssignmentBaseTest {
 
     private AssignmentDataMarshaller marshaller;
@@ -57,11 +55,11 @@ public class AssignmentDataMarshallerTest extends AssignmentBaseTest {
         super.setUp();
 
         marshaller = new AssignmentDataMarshaller();
-        inputs = new ArrayList<AssignmentRow>();
-        outputs = new ArrayList<AssignmentRow>();
-        dataTypes = new ArrayList<String>();
-        dataTypesDisplayNames = new ArrayList<String>();
-        mapCustomAssignmentProperties = new HashMap<String, List<String>>();
+        inputs = new ArrayList<>();
+        outputs = new ArrayList<>();
+        dataTypes = new ArrayList<>();
+        dataTypesDisplayNames = new ArrayList<>();
+        mapCustomAssignmentProperties = new HashMap<>();
 
         dataTypes.add("String");
         dataTypesDisplayNames.add("String");
@@ -318,13 +316,13 @@ public class AssignmentDataMarshallerTest extends AssignmentBaseTest {
     public void testCustomAssignmentProperties() {
         // "FaultToUri:Henry;Rod;Tony;,TruckType:Mazda;Tonka;Mercedes;,FromUri:,ReplyToUri:Jane;,"
         mapCustomAssignmentProperties.put("FaultToUri",
-                                          Arrays.asList(new String[]{"Henry", "Rod", "Tony"}));
+                                          Arrays.asList("Henry", "Rod", "Tony"));
         mapCustomAssignmentProperties.put("TruckType",
-                                          Arrays.asList(new String[]{"Mazda", "Tonka", "Mercedes"}));
+                                          Arrays.asList("Mazda", "Tonka", "Mercedes"));
         mapCustomAssignmentProperties.put("FromUri",
-                                          Arrays.asList(new String[]{}));
+                                          Collections.emptyList());
         mapCustomAssignmentProperties.put("ReplyToUri",
-                                          Arrays.asList(new String[]{"Jane"}));
+                                          Collections.singletonList("Jane"));
 
         AssignmentData original = new AssignmentData();
         original.setCustomAssignmentProperties(mapCustomAssignmentProperties);
@@ -337,7 +335,7 @@ public class AssignmentDataMarshallerTest extends AssignmentBaseTest {
                      demarshalled);
     }
 
-    private void marshallAndDemarshall(Map<String, List<String>> mapCustomAssignmentProperties) {
+    private void marshallAndDemarshall() {
         AssignmentData original = new AssignmentData(inputs,
                                                      outputs,
                                                      dataTypes,
@@ -352,9 +350,5 @@ public class AssignmentDataMarshallerTest extends AssignmentBaseTest {
                                                             session);
         assertEquals(original,
                      demarshalled);
-    }
-
-    private void marshallAndDemarshall() {
-        marshallAndDemarshall(null);
     }
 }

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentDataTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentDataTest.java
@@ -19,20 +19,17 @@ package org.jbpm.designer.client.shared;
 import java.util.List;
 import java.util.Map;
 
-import org.jbpm.designer.client.shared.util.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({StringUtils.class})
+@RunWith(MockitoJUnitRunner.class)
 public class AssignmentDataTest extends AssignmentBaseTest {
 
     @Before

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/shared/AssignmentTest.java
@@ -16,19 +16,16 @@
 
 package org.jbpm.designer.client.shared;
 
-import org.jbpm.designer.client.shared.util.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(StringUtils.class)
+@RunWith(MockitoJUnitRunner.class)
 public class AssignmentTest extends AssignmentBaseTest {
 
     AssignmentData ad = Mockito.mock(AssignmentData.class);
@@ -97,7 +94,7 @@ public class AssignmentTest extends AssignmentBaseTest {
         assignment.setConstant(constant);
 
         String s = assignment.toString();
-        Assignment newA = Assignment.deserialize(ad,
+        Assignment newA = assignment.deserialize(ad,
                                                  s);
         String deserializedConstant = newA.getConstant();
 
@@ -178,7 +175,7 @@ public class AssignmentTest extends AssignmentBaseTest {
         // replace the mocked encoded constant with the one that would occur at runtime
         s = s.replace(bpmn2EncodedConstant,
                       jsonEncodedConstant);
-        Assignment newA = Assignment.deserialize(ad,
+        Assignment newA = assignment.deserialize(ad,
                                                  s);
         String deserializedConstant = newA.getConstant();
 


### PR DESCRIPTION
Hi @tsurdilo,

I fixed jbpm-designer to be able to compile it with Java 11 and fixed all tests.

*** For backend:
java.xml.bind (JAXB) - REMOVED in java 11, so I added a dependency:
`javax.xml.bind:jaxb-api`

Update: replaced by `jboss-jaxb-api_2.3_spec` see https://github.com/kiegroup/jbpm-designer/pull/833#issuecomment-464015701

*** For client:
Removed dependency to Powermock since the only way to compile it with
java 11 is upgrade version to 2. But after that a lot of test failing.
(With high probability to break a lot of tests across the entire KIE
Group projects suite).

To achieve this small refactoring incorporated.
1. Allows to mock two methods in StringUtils class (removed static)
2. Ability to replace basic StringUtils by mock in Assignments class.

Depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/925
Update: doesn't depend on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/925 anymore, see https://github.com/kiegroup/jbpm-designer/pull/833#issuecomment-464015701