### PR TITLE
Enable java.awt.headless in tests to prevent TransformerServletTest failures on jenkins

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -639,6 +639,15 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>
           <filesets>


### PR DESCRIPTION
TransformerServletTest has been [failing deterministically](http://janhrcek.cz/random-failures/#/class/org.jbpm.designer.web.server.TransformerServletTest/method/testScalePDFImage%5B1%5D) on Jenkins for the past two months.


<details>
  <summary>with this exception</summary>
  <pre>
java.awt.AWTError: Can't connect to X11 window server using ':34' as the value of the DISPLAY variable.
	at sun.awt.X11GraphicsEnvironment.initDisplay(Native Method)
	at sun.awt.X11GraphicsEnvironment.access$200(X11GraphicsEnvironment.java:65)
	at sun.awt.X11GraphicsEnvironment$1.run(X11GraphicsEnvironment.java:115)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.awt.X11GraphicsEnvironment.<clinit>(X11GraphicsEnvironment.java:74)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at java.awt.GraphicsEnvironment.createGE(GraphicsEnvironment.java:103)
	at java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment(GraphicsEnvironment.java:82)
	at sun.awt.X11.XToolkit.<clinit>(XToolkit.java:132)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at java.awt.Toolkit$2.run(Toolkit.java:860)
	at java.awt.Toolkit$2.run(Toolkit.java:855)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.awt.Toolkit.getDefaultToolkit(Toolkit.java:854)
	at org.apache.batik.bridge.CursorManager.<clinit>(CursorManager.java:102)
	at org.apache.batik.bridge.BridgeContext.<init>(BridgeContext.java:1162)
	at org.apache.batik.bridge.BridgeContext.<init>(BridgeContext.java:292)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.createBridgeContext(SVGAbstractTranscoder.java:337)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.createBridgeContext(SVGAbstractTranscoder.java:313)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:194)
	at org.apache.batik.transcoder.image.ImageTranscoder.transcode(ImageTranscoder.java:92)
	at org.apache.batik.transcoder.XMLAbstractTranscoder.transcode(XMLAbstractTranscoder.java:142)
	at org.apache.batik.transcoder.SVGAbstractTranscoder.transcode(SVGAbstractTranscoder.java:156)
	at org.jbpm.designer.web.server.TransformerServletTest.testScalePDFImage(TransformerServletTest.java:485)
  </pre>
</details>

Enabling awt headless mode seems to prevent those failures.