### PR TITLE
Enable java.awt.headless in tests to prevent TransformerServletTest failures on jenkins

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -639,6 +639,15 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.awt.headless>true</java.awt.headless>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>
           <filesets>


### PR DESCRIPTION
cherry-pick https://github.com/kiegroup/jbpm-designer/pull/835
I think we should merge this because that test class is failing in basically every full downstream build, which is annoying and wastes a lot of time for people trying to get things merged quickly.