### PR TITLE
JBPM-6848: Form Generation fails generating forms for classes on external dependencies

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -604,6 +604,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-data-modeller-integration-backend</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderServiceTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/taskforms/builder/BPMNKieWorkbenchFormBuilderServiceTest.java
@@ -24,9 +24,12 @@ import org.jbpm.designer.bpmn2.utils.Bpmn2Loader;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
 import org.kie.workbench.common.forms.commons.shared.layout.impl.StaticFormLayoutTemplateGenerator;
+import org.kie.workbench.common.forms.data.modeller.service.ext.ModelReaderService;
+import org.kie.workbench.common.forms.data.modeller.service.impl.ext.dmo.runtime.RuntimeDMOModelReader;
 import org.kie.workbench.common.forms.editor.service.backend.FormModelHandlerManager;
-import org.kie.workbench.common.forms.editor.service.shared.VFSFormFinderService;
+import org.kie.workbench.common.forms.editor.service.shared.ModuleFormFinderService;
 import org.kie.workbench.common.forms.editor.service.shared.model.impl.FormModelSynchronizationUtilImpl;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
 import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
@@ -73,7 +76,10 @@ public class BPMNKieWorkbenchFormBuilderServiceTest {
     private FormModelHandlerManager formModelHandlerManager;
 
     @Mock
-    private VFSFormFinderService vfsFormFinderService;
+    private ModelReaderService<Path> modelReaderService;
+
+    @Mock
+    private ModuleFormFinderService moduleFormFinderService;
 
     @Mock
     private CommentedOptionFactory commentedOptionFactory;
@@ -135,6 +141,8 @@ public class BPMNKieWorkbenchFormBuilderServiceTest {
             }
         });
 
+        when(modelReaderService.getModelReader(any())).thenReturn(new RuntimeDMOModelReader(getClass().getClassLoader(), new RawMVELEvaluator()));
+
         builderService = new BPMNKieWorkbenchFormBuilderService(ioService,
                                                                 formModelHandlerManager,
                                                                 new BPMNFormModelGeneratorImpl(moduleService,
@@ -142,8 +150,9 @@ public class BPMNKieWorkbenchFormBuilderServiceTest {
                                                                 formSerializer,
                                                                 new StaticFormLayoutTemplateGenerator(),
                                                                 new BPMNVFSFormDefinitionGeneratorService(fieldManager,
+                                                                                                          modelReaderService,
                                                                                                           formModelHandlerManager,
-                                                                                                          vfsFormFinderService,
+                                                                                                          moduleFormFinderService,
                                                                                                           formSerializer,
                                                                                                           ioService,
                                                                                                           commentedOptionFactory,


### PR DESCRIPTION
Fixing broken tests due to some api changes.

@tomasdavidorg @tsurdilo could you please review?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/drools/pull/2277
https://github.com/kiegroup/kie-wb-common/pull/2525
https://github.com/kiegroup/jbpm-wb/pull/1316
https://github.com/kiegroup/jbpm-designer/pull/842
https://github.com/kiegroup/kie-wb-distributions/pull/898