### PR TITLE
BAPL-1395/JBPM-8124 - Legacy Designer Files

### DIFF
--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/handlers/NewCaseDefinitionHandlerTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/handlers/NewCaseDefinitionHandlerTest.java
@@ -32,6 +32,7 @@ import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -44,7 +45,6 @@ public class NewCaseDefinitionHandlerTest {
 
     @Mock
     private DesignerAssetService designerAssetService;
-    private Caller<DesignerAssetService> designerAssetServiceCaller;
 
     @Mock
     private PlaceManager placeManager;
@@ -56,13 +56,11 @@ public class NewCaseDefinitionHandlerTest {
 
     @Before
     public void setup() {
-        designerAssetServiceCaller = new CallerMock<>(designerAssetService);
+        Caller<DesignerAssetService> designerAssetServiceCaller = new CallerMock<>(designerAssetService);
         newCaseDefinitionHandler = new NewCaseDefinitionHandler(designerAssetServiceCaller,
                                                                 placeManager,
-                                                                null) {
-            {
-                newResourceSuccessEvent = newResourceSuccessEventMock;
-            }
+                                                                null,
+                                                                newResourceSuccessEventMock) {
 
             @Override
             protected String buildFileName(final String baseFileName,
@@ -72,6 +70,7 @@ public class NewCaseDefinitionHandlerTest {
 
             @Override
             protected void notifySuccess() {
+                /* Since notificationEvent field is null we override this method to avoid any calls to it. */
             }
         };
     }
@@ -93,5 +92,7 @@ public class NewCaseDefinitionHandlerTest {
                times(1)).fire(any(NewResourceSuccessEvent.class));
         verify(placeManager,
                times(1)).goTo(path);
+
+        assertFalse(newCaseDefinitionHandler.isProjectAsset());
     }
 }

--- a/jbpm-designer-client/src/test/java/org/jbpm/designer/client/handlers/NewProcessHandlerTest.java
+++ b/jbpm-designer-client/src/test/java/org/jbpm/designer/client/handlers/NewProcessHandlerTest.java
@@ -32,6 +32,7 @@ import org.uberfire.mocks.CallerMock;
 import org.uberfire.mocks.EventSourceMock;
 import org.uberfire.workbench.type.ResourceTypeDefinition;
 
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -44,7 +45,6 @@ public class NewProcessHandlerTest {
 
     @Mock
     private DesignerAssetService designerAssetService;
-    private Caller<DesignerAssetService> designerAssetServiceCaller;
 
     @Mock
     private PlaceManager placeManager;
@@ -56,14 +56,11 @@ public class NewProcessHandlerTest {
 
     @Before
     public void setup() {
-        designerAssetServiceCaller = new CallerMock<>(designerAssetService);
+        Caller<DesignerAssetService> designerAssetServiceCaller = new CallerMock<>(designerAssetService);
         newProcessHandler = new NewProcessHandler(designerAssetServiceCaller,
                                                   placeManager,
-                                                  null) {
-            {
-                newResourceSuccessEvent = newResourceSuccessEventMock;
-            }
-
+                                                  null,
+                                                  newResourceSuccessEventMock) {
             @Override
             protected String buildFileName(final String baseFileName,
                                            final ResourceTypeDefinition resourceType) {
@@ -72,6 +69,7 @@ public class NewProcessHandlerTest {
 
             @Override
             protected void notifySuccess() {
+                /* Since notificationEvent field is null we override this method to avoid any calls to it. */
             }
         };
     }
@@ -92,5 +90,7 @@ public class NewProcessHandlerTest {
                times(1)).fire(any(NewResourceSuccessEvent.class));
         verify(placeManager,
                times(1)).goTo(path);
+
+        assertFalse(newProcessHandler.isProjectAsset());
     }
 }


### PR DESCRIPTION
This PR relates to both this JIRAs:

- [BAPL-1395 - Support Legacy Designer Files in Stunner](https://issues.redhat.com/browse/BAPL-1395)
- [JBPM-8124 - Remove legacy process designer from the asset list](https://issues.redhat.com/browse/JBPM-8124)

This removes the following designers from the asset creation list:
- Businnes Process (legacy)
- Case Definition (legacy)

Non-migrated files can still be opened using those legacy designers. This allows the edition, migration and removal of legacy files in a safer, more usual way.