### PR TITLE
AF-2410: default:// as main file system

### DIFF
--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/repository/RepositoryBaseTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/repository/RepositoryBaseTest.java
@@ -28,7 +28,7 @@ public class RepositoryBaseTest {
 
     protected static final String REPOSITORY_ROOT = (System.getProperty("java.io.tmpdir").endsWith(File.separator)
             ? System.getProperty("java.io.tmpdir") : (System.getProperty("java.io.tmpdir") + File.separator)) + "designer-repo";
-    protected static final String VFS_REPOSITORY_ROOT = "default://" + REPOSITORY_ROOT;
+    protected static final String VFS_REPOSITORY_ROOT = "file://" + REPOSITORY_ROOT;
 
     protected JbpmProfileImpl profile;
     protected RepositoryDescriptor descriptor;

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/server/BusinessProcessCopyHelperTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/server/BusinessProcessCopyHelperTest.java
@@ -82,8 +82,8 @@ public class BusinessProcessCopyHelperTest {
 
     @Test
     public void testCopy() {
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
-        when(pathDestination.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
+        when(pathDestination.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
         when(pathDestination.getFileName()).thenReturn("MyNewProcess.bpmn2");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(DEFAULT_PROCESS);
 
@@ -118,8 +118,8 @@ public class BusinessProcessCopyHelperTest {
 
     @Test
     public void testCopyIDWithMultibyteCharsAndSpaces() {
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
-        when(pathDestination.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
+        when(pathDestination.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
         when(pathDestination.getFileName()).thenReturn("Эож ты дольорэ     My New Process  어디야.bpmn2");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(DEFAULT_PROCESS);
 
@@ -154,8 +154,8 @@ public class BusinessProcessCopyHelperTest {
 
     @Test
     public void testCopyIDWithInvalidID() {
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
-        when(pathDestination.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyProcess.bpmn2");
+        when(pathDestination.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/MyNewProcess.bpmn2");
         when(pathDestination.getFileName()).thenReturn("  << my process    >>");
         when(ioService.readAllString(any(org.uberfire.java.nio.file.Path.class))).thenReturn(DEFAULT_PROCESS);
 

--- a/jbpm-designer-backend/src/test/java/org/jbpm/designer/server/service/DefaultDesignerAssetServiceTest.java
+++ b/jbpm-designer-backend/src/test/java/org/jbpm/designer/server/service/DefaultDesignerAssetServiceTest.java
@@ -130,7 +130,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateProcessWithDefaultPackage() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources");
         when(pathSource.getFileName()).thenReturn("MyProcess.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -165,7 +165,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateProcessWithDefaultPackageNoProject() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/src/main");
+        when(pathSource.toURI()).thenReturn("file://p0/src/main");
         when(pathSource.getFileName()).thenReturn("MyProcess.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -200,7 +200,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateProcessWithSingleLevelPackage() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/org");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/org");
         when(pathSource.getFileName()).thenReturn("MyProcess.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -235,7 +235,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateProcessWithMultiLevelPackage() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/org/jbpm/test/process");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/org/jbpm/test/process");
         when(pathSource.getFileName()).thenReturn("MyProcess.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -282,7 +282,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateCaseDefinitionWithDefaultPackage() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/org/jbpm/test/cases");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/org/jbpm/test/cases");
         when(pathSource.getFileName()).thenReturn("MyCase.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -346,7 +346,7 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
     @Test
     public void testCreateCaseDefinitionWithPackageNoPrefix() throws Exception {
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/src/main/resources/org/jbpm/test/cases");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/src/main/resources/org/jbpm/test/cases");
         when(pathSource.getFileName()).thenReturn("MyCase.bpmn2");
 
         DefaultDesignerAssetService assetService = new DefaultDesignerAssetService();
@@ -402,10 +402,10 @@ public class DefaultDesignerAssetServiceTest extends RepositoryBaseTest {
         assetService.setIoService(ioService);
 
         final Path packagePath = mock(Path.class);
-        when(packagePath.toURI()).thenReturn("default://p0/Evaluation/");
+        when(packagePath.toURI()).thenReturn("file://p0/Evaluation/");
 
         final Path pathSource = mock(Path.class);
-        when(pathSource.toURI()).thenReturn("default://p0/Evaluation/.caseproject");
+        when(pathSource.toURI()).thenReturn("file://p0/Evaluation/.caseproject");
         when(pathSource.getFileName()).thenReturn(".caseproject");
         assetService.createProcess(pathSource,
                                    ".caseproject");

--- a/jbpm-designer-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
+++ b/jbpm-designer-backend/src/test/resources/META-INF/services/org.uberfire.java.nio.file.spi.FileSystemProvider
@@ -1,3 +1,3 @@
-org.uberfire.java.nio.fs.file.SimpleFileSystemProvider  # file system provider, also default (1st)
 org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider
+org.uberfire.java.nio.fs.file.SimpleFileSystemProvider
 # org.kie.commons.java.nio.fs.eclipse.EclipseFileSystemProvider  # eclipse provider


### PR DESCRIPTION
## Intention

* Disable JGit specific features when JGit is not the default FS
* Add a switch to choose between Monitoring and Simplified Monitoring

## Simplified Monitoring 
Simplified monitoring is the K8S FS based solution. This can't use JGit specific parts so they are disabled (Like _Pages_)

Possible values:
* -Dorg.appformer.server.simplified.monitoring.enabled=true/false

## Related PRs:
* https://github.com/kiegroup/appformer/pull/882
* https://github.com/kiegroup/kie-wb-common/pull/3128
* https://github.com/kiegroup/drools-wb/pull/1363
* https://github.com/kiegroup/jbpm-designer/pull/881