### PR TITLE
JBPM-9231: removed exlusion of batik-ext

### DIFF
--- a/jbpm-designer-backend/pom.xml
+++ b/jbpm-designer-backend/pom.xml
@@ -260,12 +260,6 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-dom</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.xmlgraphics</groupId>
-          <artifactId>batik-ext</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9231

There is new version of Apache Batik 1.13
Parent PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1395
Dependent PR kiegroup/droolsjbpm-integration#2183