### PR TITLE
[ISSUE 117] build-chain upgraded to v2.6.13

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,16 @@
 
 <details>
 <summary>
+How to replicate CI configuration locally?
+</summary>
+
+We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
+
+[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
+</details>
+
+<details>
+<summary>
 How to retest this PR or trigger a specific build:
 </summary>
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,9 +15,9 @@
 How to replicate CI configuration locally?
 </summary>
 
-We do "simple" maven builds, they are just basically maven commands, but just because we have multiple repositories related between them and one change could affect several of those projects by multiple pull requests, we use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
-
-[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is not only a github-action tool but a CLI one, so in case you posted multiple pull requests related with this change you can easily reproduce the same build by executing it locally. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
+Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
+ 
+[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
 </details>
 
 <details>

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,9 +53,9 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@v2.6.11
+        uses: kiegroup/github-action-build-chain@issues/117
         with:
-          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH}/.ci/pull-request-config.yaml
+          definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Check Surefire Report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,7 +53,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.java-version }}-maven${{ matrix.maven-version }}-m2
       - name: Build Chain ${{ matrix.java-version }}. Maven ${{ matrix.maven-version }}
         id: build-chain
-        uses: kiegroup/github-action-build-chain@issues/117
+        uses: kiegroup/github-action-build-chain@v2.6.13
         with:
           definition-file: https://raw.githubusercontent.com/${GROUP}/droolsjbpm-build-bootstrap/${BRANCH:main}/.ci/pull-request-config.yaml
         env:


### PR DESCRIPTION
See build-chain update details at https://github.com/kiegroup/github-action-build-chain/pull/190

related PRs:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1798
- https://github.com/kiegroup/kie-soup/pull/235
- https://github.com/kiegroup/droolsjbpm-knowledge/pull/576
- https://github.com/kiegroup/drools/pull/3959
- https://github.com/kiegroup/optaplanner/pull/1640
- https://github.com/kiegroup/lienzo-core/pull/156
- https://github.com/kiegroup/lienzo-tests/pull/130
- https://github.com/kiegroup/appformer/pull/1208
- https://github.com/kiegroup/kie-uberfire-extensions/pull/127
- https://github.com/kiegroup/jbpm/pull/2053
- https://github.com/kiegroup/kie-jpmml-integration/pull/69
- https://github.com/kiegroup/droolsjbpm-integration/pull/2638
- https://github.com/kiegroup/kie-wb-playground/pull/122
- https://github.com/kiegroup/kie-wb-common/pull/3699
- https://github.com/kiegroup/drools-wb/pull/1525
- https://github.com/kiegroup/jbpm-designer/pull/921
- https://github.com/kiegroup/jbpm-work-items/pull/222
- https://github.com/kiegroup/jbpm-wb/pull/1527
- https://github.com/kiegroup/optaplanner-wb/pull/408
- https://github.com/kiegroup/kie-wb-distributions/pull/1143
- https://github.com/kiegroup/openshift-drools-hacep/pull/121
- https://github.com/kiegroup/process-migration-service/pull/31
- https://github.com/kiegroup/optaweb-employee-rostering/pull/710
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/589
- https://github.com/kiegroup/kie-docs/pull/3981
- https://github.com/kiegroup/kogito-pipelines/pull/309
- https://github.com/kiegroup/kogito-runtimes/pull/1686
- https://github.com/kiegroup/kogito-apps/pull/1084
- https://github.com/kiegroup/kogito-examples/pull/961
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1150